### PR TITLE
Some improvements to CI

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.5'
+          version: '1'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,10 +1,12 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 0 * * *
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,25 +45,3 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1.5'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.update()
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-      - run: |
-          julia --project=docs -e '
-            using Documenter: doctest
-            using psrsearch'
-      - run: julia --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
* Documentation: build with latest version of Julia 1.x
* TagBot: use newer setup, see [documentation](https://github.com/JuliaRegistries/TagBot/blob/afea108e2cd6116e3cf366b55f116b8c257ae0f2/README.md#setup)
* CI: remove duplicate documentation job

Usually I run CI on 3 versions of Julia:

* the oldest one I claim support for (in your case it would be `"1.0"`)
* the latest stable version (can be indicated with `"1"`)
* `"nightly"`

I didn't change this, leaving the decision up to you.

Also, for most of my packages I don't fiddle too much with internals, where 32-
vs 64-bit would matter, so I usually don't run CI on 32-bit systems at all, to
save some resources.  I'm leaving also this up to you :wink: