### PR TITLE
Minor changes to documentation setup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,14 @@ version = "0.1.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
 
 [extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Documenter", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-psrsearch = "b7fe27a0-ab0c-4e8e-b203-2a459fc90788"
+
+[compat]
+Documenter = "~0.26"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,11 +4,11 @@ using Documenter
 makedocs(;
     modules=[psrsearch],
     authors="Matteo Bachetti <matteo@matteobachetti.it> and contributors",
-    repo="https://github.com/matteobachetti/psrsearch.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/JuliaAstro/psrsearch.jl/blob/{commit}{path}#L{line}",
     sitename="psrsearch.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://matteobachetti.github.io/psrsearch.jl",
+        canonical="https://juliaastro.github.io/psrsearch.jl",
         assets=String[],
     ),
     pages=[
@@ -17,6 +17,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/matteobachetti/psrsearch.jl",
+    repo="github.com/JuliaAstro/psrsearch.jl",
     devbranch = "main"
 )


### PR DESCRIPTION
* Package's project shouldn't list `Test` and `Documenter` as dependencies:
  `Test` is already in the `extra` section, and I moved also `Documenter` there
* the environment of the documentation shouldn't list the package itself, that
  one is automatically installed by [the CI job](https://github.com/JuliaAstro/psrsearch.jl/blob/59205746747b88b5083adad7f6d4b5c1c1c1ebe5/.github/workflows/Documentation.yml#L19)
  which will build the documentation
* it's also better to specify compatibility of `Documenter.jl`, to prevent
  building of documentation from stopping to work when there is a new breaking
  release of the package
* updated links in `docs/make.jl`